### PR TITLE
correção da aba em destaque (selecionada) de Eventos para Fórum

### DIFF
--- a/paginas/topicoForum.html
+++ b/paginas/topicoForum.html
@@ -37,9 +37,9 @@
                 </li>
                 <li class="cabecalho__itens__item"><a class="cabecalho__itens__link" href="noticias.html">Notícias</a>
                 </li>
-                <li class="cabecalho__itens__item"><a class="cabecalho__itens__link__selecionado"
+                <li class="cabecalho__itens__item"><a class="cabecalho__itens__link"
                         href="eventos.html">Eventos</a></li>
-                <li class="cabecalho__itens__item"><a class="cabecalho__itens__link" href="forum.html">Fórum</a></li>
+                <li class="cabecalho__itens__item"><a class="cabecalho__itens__link__selecionado" href="forum.html">Fórum</a></li>
                 <li class="cabecalho__itens__item"><a class="cabecalho__itens__link"
                         href="#calendario_academico">Calendário Acadêmico</a></li>
             </ul>


### PR DESCRIPTION
a aba de Eventos está marcada como selecionada ao invés da aba Fórum ao entrar no tópico do baixo-assinado
![image](https://github.com/Engenharia-de-Software-da-UEPA/projeto-desenvolvimento-web/assets/76229775/d7cd1337-186e-4b2e-bed6-74be7b4a2745)
